### PR TITLE
Display fatal_dialog when dashboard generation fails

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -15,12 +15,8 @@ renderFlexDashboard <- function(id, version = NULL) {
   contents <- paste(readLines(tmp2), collapse = "\n")
 
   caps$render(
-    "#rcloud-flexdashboard",
-    paste0(
-      "<iframe frameBorder=\"0\" width=\"100%\" height=\"100%\" srcdoc=\"",
-      gsub("\"", "&quot;", contents),
-      "\"></iframe>"
-    )
+    "#rcloud-flexdashboard", 
+    gsub("\"", "&quot;", contents)
   )
 
   invisible()

--- a/inst/javascript/rcloud.flexdashboard.js
+++ b/inst/javascript/rcloud.flexdashboard.js
@@ -35,7 +35,15 @@
 
         render: function(target, html, k) {
             $('#rcloud-flexdashboard-loading').remove();
-            $(target).html(html);
+            var content = "<iframe frameBorder=\"0\" width=\"100%\" height=\"100%\" srcdoc=\"" + html + "\"></iframe>";
+            var parsed = $(html)
+            var title = parsed.filter('title').text();
+            if(title!=="") {
+              document.title = title
+            } else {
+              document.title = "RCloud flexdashboard"
+            }           
+            $(target).html(content);
             k(null, target);
         }
     }

--- a/inst/javascript/rcloud.flexdashboard.js
+++ b/inst/javascript/rcloud.flexdashboard.js
@@ -15,6 +15,10 @@
                 });
 
             } else {
+                onError = function(x) {
+                    $('#rcloud-flexdashboard-loading').remove();
+                    RCloud.UI.fatal_dialog(x.message, "Close")
+                }
 
                 oc = RCloud.promisify_paths(ocaps, [
                     ['renderFlexDashboard']
@@ -22,7 +26,7 @@
 
                 window.RCloudFlexDashboard = window.RCloudFlexDashboard || {};
                 window.RCloudFlexDashboard.renderFlexDashboard = function(x, y) {
-                    oc.renderFlexDashboard(x, y).then(function() {});
+                    oc.renderFlexDashboard(x, y).catch(onError).then(function() {});
                 }
             }
 

--- a/inst/www/js/rcloud-flexdashboard.js
+++ b/inst/www/js/rcloud-flexdashboard.js
@@ -13,6 +13,11 @@ function main() {
         return res;
     }
 
+    function onError(e) {
+        $('#rcloud-flexdashboard-loading').remove();
+        RCloud.UI.fatal_dialog(e.message, "Close");
+    }
+
     rclient = RClient.create({
         debug: false,
         mode: "client", // "IDE" = edit (separated), "call" = API (one process), "client" = JS (currently one process but may change)
@@ -45,6 +50,9 @@ function main() {
             promise = promise.then(function() {
                 // Just tell R to load the rcloud.flexdashboard package,
                 // and the packag will do the rest
+                if(!rcloud._ocaps.load_module_package) {
+                  throw new Error("Can't load 'rcloud.flexdashboard' - loading of modules is disabled.");
+                }
                 rcloud._ocaps.load_module_package(
                     "rcloud.flexdashboard",
                     function(x) {
@@ -56,6 +64,7 @@ function main() {
                     }
                 );
             });
+            promise = promise.catch(onError);
             return true;
         },
         on_data: RCloud.session.on_data,

--- a/inst/www/js/rcloud-flexdashboard.js
+++ b/inst/www/js/rcloud-flexdashboard.js
@@ -50,9 +50,6 @@ function main() {
             promise = promise.then(function() {
                 // Just tell R to load the rcloud.flexdashboard package,
                 // and the packag will do the rest
-                if(!rcloud._ocaps.load_module_package) {
-                  throw new Error("Can't load 'rcloud.flexdashboard' - loading of modules is disabled.");
-                }
                 rcloud._ocaps.load_module_package(
                     "rcloud.flexdashboard",
                     function(x) {


### PR DESCRIPTION
As a first iteration I implemented the 'good start' solution: the fatal_dialog is displayed and holds the stack-trace and the 'loading' panel is removed. So when user clicks the 'close' button on the fatal_dialog they will be presented with a blank page.

![capture](https://cloud.githubusercontent.com/assets/578443/25171323/6237dfd4-24e5-11e7-90d5-fa15e691a1d2.PNG)

The error is handled by JS Promise exception handling.  

The other possibility to fix this issue would be to make the render.R catch the exception thrown by rmarkdown::render function and display the fatal_dialog from there...

Much improvement could be made here:
* Display the error message directly on the page, not in fatal_error.
* Display the 

error message and stack-trace separately - so users are presented with a simple message by default and they can view the stack trace on request. This would rather require the latter approach, as rserve.js concatenates the error message and the stacktrace so these then would have to be split... Also the stack-trace holds too-much information - includes rserve calls as well, which are useful for debugging but may not be that useful for end-users.
