### PR TITLE
Fix #16 by exporting css notebook assets

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -2,8 +2,9 @@
 renderFlexDashboard <- function(id, version = NULL) {
   tmp_dir <- tempfile("flexdashboard")
   dir.create(tmp_dir)
-
-    tmp <- tempfile(tmpdir = tmp_dir, fileext = ".Rmd")
+  on.exit(unlink(tmp_dir), add = TRUE)
+  
+  tmp <- tempfile(tmpdir = tmp_dir, fileext = ".Rmd")
   exportRmd(id, version, file = tmp)
   exportCss(id, version, tmp_dir)
   
@@ -12,9 +13,8 @@ renderFlexDashboard <- function(id, version = NULL) {
     input = tmp,
     output_file = tmp2
   )
-
   contents <- paste(readLines(tmp2), collapse = "\n")
-  contents <- paste0(contents, "<!-- ", tmp_dir, "-->")
+
   caps$render(
     "#rcloud-flexdashboard", 
     gsub("\"", "&quot;", contents)

--- a/R/render.R
+++ b/R/render.R
@@ -1,23 +1,50 @@
 
 renderFlexDashboard <- function(id, version = NULL) {
-
-  tmp <- tempfile(fileext = ".Rmd")
-  on.exit(unlink(tmp), add = TRUE)
+#  tmp <- tempfile(fileext = ".Rmd") 
+#  on.exit(unlink(tmp), add = TRUE)
+  tmp_dir <- tempfile("flexdashboard")
+  dir.create(tmp_dir)
+#  on.exit(unlink(tmp_dir, recursive = TRUE), add = TRUE)
+  tmp <- tempfile(tmpdir = tmp_dir, fileext = ".Rmd")
   exportRmd(id, version, file = tmp)
-
-  tmp2 <- tempfile(fileext = ".html")
-  on.exit(unlink(tmp2), add = TRUE)
+  exportCss(id, version, tmp_dir)
+  
+  tmp2 <- tempfile(fileext = ".html", tmpdir = tmp_dir)
+#  tmp2 <- tempfile(fileext = ".html")
+#  on.exit(unlink(tmp2), add = TRUE)
   render(
     input = tmp,
     output_file = tmp2
   )
 
   contents <- paste(readLines(tmp2), collapse = "\n")
-
+  contents <- paste0(contents, "<!-- ", tmp_dir, "-->")
   caps$render(
     "#rcloud-flexdashboard", 
     gsub("\"", "&quot;", contents)
   )
 
   invisible()
+}
+
+
+exportCss <- function(notebook_id, version = NULL, tmp_dir) {
+    res <- rcloud.support::rcloud.get.notebook(notebook_id, version)
+    
+    if (! res$ok) {
+      return(NULL)
+    }
+    
+    cells <- res$content$files
+    cells <- cells[grep(".+\\.css$", names(cells))]
+    lapply(cells, function(cell) {
+      css_file <- file.path(tmp_dir, cell$filename)
+      file.create(css_file);
+      cat(format_cell(cell), file = css_file)
+      return(css_file)
+    });
+}
+
+format_cell <- function(cell) {
+  paste0(cell$content, "\n")
 }

--- a/R/render.R
+++ b/R/render.R
@@ -1,17 +1,13 @@
 
 renderFlexDashboard <- function(id, version = NULL) {
-#  tmp <- tempfile(fileext = ".Rmd") 
-#  on.exit(unlink(tmp), add = TRUE)
   tmp_dir <- tempfile("flexdashboard")
   dir.create(tmp_dir)
-#  on.exit(unlink(tmp_dir, recursive = TRUE), add = TRUE)
-  tmp <- tempfile(tmpdir = tmp_dir, fileext = ".Rmd")
+
+    tmp <- tempfile(tmpdir = tmp_dir, fileext = ".Rmd")
   exportRmd(id, version, file = tmp)
   exportCss(id, version, tmp_dir)
   
   tmp2 <- tempfile(fileext = ".html", tmpdir = tmp_dir)
-#  tmp2 <- tempfile(fileext = ".html")
-#  on.exit(unlink(tmp2), add = TRUE)
   render(
     input = tmp,
     output_file = tmp2


### PR DESCRIPTION
When notebook is exported as Rmd file during flexdashboard generation all CSS assets are put next to the temporary rmd file.