### PR TITLE
Fix #3 by displaying currently processed knitr chunk label on the page

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,4 @@
+
 importFrom(flexdashboard, flex_dashboard)
 importFrom(rcloud.rmd, exportRmd)
 importFrom(rcloud.support, rcloud.get.notebook)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,4 +1,3 @@
-
 importFrom(flexdashboard, flex_dashboard)
 importFrom(rcloud.rmd, exportRmd)
 importFrom(rcloud.support, rcloud.get.notebook)

--- a/R/render.R
+++ b/R/render.R
@@ -7,6 +7,9 @@ renderFlexDashboard <- function(id, version = NULL) {
 
   tmp2 <- tempfile(fileext = ".html")
   on.exit(unlink(tmp2), add = TRUE)
+  
+  knitr:::knit_hooks$set(eval = progress_hook)
+  on.exit(knitr:::knit_hooks$set(eval = NULL), add = TRUE)
   render(
     input = tmp,
     output_file = tmp2
@@ -21,3 +24,20 @@ renderFlexDashboard <- function(id, version = NULL) {
 
   invisible()
 }
+
+progress <- function(status) {
+  if(exists("caps")) {
+    caps$progress(
+      "#rcloud-flexdashboard-progress", 
+      gsub("\"", "&quot;", paste0("Processing ", status))
+    )
+  } else {
+    cat(gsub("\"", "&quot;", paste0("Processing ", status)))
+  }
+}
+
+progress_hook <- function(before, options, envir) {
+  progress(options$label)
+  options
+}
+

--- a/inst/javascript/rcloud.flexdashboard.js
+++ b/inst/javascript/rcloud.flexdashboard.js
@@ -45,6 +45,10 @@
             }
             $(target).html(content);
             k(null, target);
+        },
+        progress: function(target, html, k) {
+            $('#rcloud-flexdashboard-progress').html(html);
+            k(null, target);
         }
     };
 

--- a/inst/www/flexdashboard.html
+++ b/inst/www/flexdashboard.html
@@ -14,6 +14,8 @@
     <div id="rcloud-flexdashboard">
       <div id="rcloud-flexdashboard-loading" class="centered">
         <img src="RCloud-flexo.svg" width="400px" />
+        <div id="rcloud-flexdashboard-progress" class="ui-widget">
+        </div>
       </div>
     </div>
   </body>


### PR DESCRIPTION
The progress information that is printed in the console comes from knitr, which uses txtProgressBar.  Because the txtProgressBar is a regular function defined in the 'utils' namespace it isn't easy and safe to replace. (I think r.utils could be used in here, but the version that is available on CRAN doesn't work with R 3.2.3 so I ruled it out as a candidate for the solution)

 Here I used knitr hooks mechanism which I treat as event source. The amount of information that is available is pretty limited but at least the label of currently processed code chunk is there. 

Long term solution would require rising a feature request in knitr project to expose a global option, e.g. 'progress.monitor.factory' which knitr would use to request a new instance of progress monitor and then notify it about processing progress.
 