### PR TITLE
Add support for shiny and shiny_prerendered runtimes.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,8 @@ License: MIT + file LICENSE
 RCloud-Extension: gui
 Encoding: UTF-8
 RoxygenNote: 5.0.1.9000
+Suggests:
+    rcloud.shiny
 Imports:
     flexdashboard,
     rmarkdown,

--- a/R/onload.R
+++ b/R/onload.R
@@ -2,6 +2,12 @@
 caps <- NULL
 
 .onLoad <- function(libname, pkgname) {
+  
+  if (requireNamespace("rcloud.shiny", quietly = TRUE)) {
+    # We are loading this here to make sure that rcloud.shiny registers its ocaps
+    # yet still keep rcloud.shiny as an optional pacakge.
+    library("rcloud.shiny")
+  }
 
   path <- system.file(
     package = "rcloud.flexdashboard",

--- a/R/render.R
+++ b/R/render.R
@@ -4,34 +4,50 @@ renderFlexDashboard <- function(id, version = NULL) {
     stop("Notebook \"", URLencode(id, TRUE), "\" does not exist or has not been published")
   tmp_dir <- tempfile("flexdashboard")
   dir.create(tmp_dir)
-  on.exit(unlink(tmp_dir), add = TRUE)
   
-  tmp <- tempfile(tmpdir = tmp_dir, fileext = ".Rmd")
-  exportRmd(id, version, file = tmp)
+  tmpRmd <- tempfile(tmpdir = tmp_dir, fileext = ".Rmd")
+  exportRmd(id, version, file = tmpRmd)
   exportCss(id, version, tmp_dir)
   
-  tmp2 <- tempfile(fileext = ".html", tmpdir = tmp_dir)
+  front_matter <- rmarkdown:::yaml_front_matter(tmpRmd)
+  
+  
   knitr:::knit_hooks$set(eval = progress_hook)
   on.exit(knitr:::knit_hooks$set(eval = NULL), add = TRUE)
-  render(
-    input = tmp,
-    output_file = tmp2
-  )
-  contents <- paste(readLines(tmp2), collapse = "\n")
-
-  caps$render(
-    "#rcloud-flexdashboard", 
-    gsub("\"", "&quot;", contents)
-  )
+  
+  if('runtime' %in% names(front_matter) && front_matter$runtime %in% c('shiny', 'shiny_prerendered')) {
+    addSessionCloseCallback(rmDirCallback(tmp_dir))
+    if (requireNamespace("rcloud.shiny", quietly = TRUE)) {
+      rmarkdown.run.override(tmpRmd, 
+                             auto_reload = FALSE,
+                             renderer = function(url) {   
+                               caps$renderShinyUrl("#rcloud-flexdashboard", url)
+                               rcw.result(run = function(...) { }, body = "")
+                             })
+    } else {
+      stop("flexdashboards that use shiny runtime require rcloud.shiny package, please install it and try again.")
+    }
+  } else {
+    tmpHtml <- tempfile(fileext = ".html", tmpdir = tmp_dir)
+    on.exit(unlink(tmp_dir), add = TRUE)
+    render(
+      input = tmpRmd, 
+      output_file = basename(tmpHtml)
+    )
+    contents <- paste(readLines(tmpHtml), collapse = "\n")
+    caps$render(
+      "#rcloud-flexdashboard", 
+      gsub("\"", "&quot;", contents)
+    )
+  }
 
   invisible()
 }
 
-
 exportCss <- function(notebook_id, version = NULL, tmp_dir) {
     res <- rcloud.support::rcloud.get.notebook(notebook_id, version)
     
-    if (! res$ok) {
+    if (!res$ok) {
       return(NULL)
     }
     
@@ -45,9 +61,30 @@ exportCss <- function(notebook_id, version = NULL, tmp_dir) {
     });
 }
 
+rmDirCallback <- function(dir.path) {
+  directory <- dir.path
+  function() {
+    if(!is.null(directory) && file.exists(directory)) {
+      unlink(directory, recursive = TRUE)
+    }
+  }
+}
+
+addSessionCloseCallback <- function(FUN) {
+  f <- .GlobalEnv$.Rserve.done
+  .GlobalEnv$.Rserve.done <- function(...) {
+    FUN()
+    if(is.function(f)) {
+      f(...)
+    }
+  }
+  
+}
+
 format_cell <- function(cell) {
   paste0(cell$content, "\n")
 }
+
 progress <- function(status) {
   if(exists("caps")) {
     caps$progress(
@@ -63,4 +100,3 @@ progress_hook <- function(before, options, envir) {
   progress(options$label)
   options
 }
-

--- a/R/rmarkdown-override.R
+++ b/R/rmarkdown-override.R
@@ -1,0 +1,168 @@
+# the source in this file is licensed under GPL-3, copyright RStudio and contributors; see
+# https://github.com/rstudio/rmarkdown/blob/master/DESCRIPTION for details.
+
+# Based on rmarkdown:::run
+# Main changes:
+# * Don't launch browser
+# * Integrate with rcloud.shiny instead of invoking shiny functions.
+rmarkdown.run.override <- function(file, dir = dirname(file), auto_reload = TRUE, shiny_args = NULL, render_args = NULL, renderer = NULL) {
+  
+  default_file <- basename(file)
+  target_file <- file
+  dir <- rmarkdown:::normalize_path(dir)
+  encoding <- if (is.null(render_args$encoding)) 
+    "UTF-8"
+  else render_args$encoding
+  if (is.null(render_args$envir)) 
+    render_args$envir <- parent.frame()
+  if (!is.null(target_file)) 
+    runtime <- yaml_front_matter(target_file, encoding)$runtime
+  else runtime <- NULL
+  if (rmarkdown:::is_shiny_prerendered(runtime)) {
+    app <- shiny_prerendered_app.override(target_file, encoding = encoding, 
+                                 render_args = render_args, renderer = renderer)
+  } else {
+    onStart <- function() {
+      global_r <- rmarkdown:::file.path.ci(dir, "global.R")
+      if (file.exists(global_r)) {
+        source(global_r, local = FALSE)
+      }
+      shiny::addResourcePath("rmd_resources", rmarkdown:::rmarkdown_system_file("rmd/h/rmarkdown"))
+    }
+    on.exit({
+      assign('evaluated_global_chunks', character(), rmarkdown:::.globals)
+    }, add = TRUE)
+    rcloud.shiny:::rcloud.shinyAppInternal(ui = rmarkdown:::rmarkdown_shiny_ui(dir, default_file), 
+                                           uiPattern = "^/$|^/index\\.html?$|^(/.*\\.[Rr][Mm][Dd])$", 
+                                           onStart = onStart, 
+                                           server = rmarkdown_shiny_server.override(dir, 
+                                                                                    default_file, encoding, auto_reload, render_args),
+                                           renderer = renderer)
+  }
+}
+
+# Tweaked rmarkdown:::rmarkdown_shiny_server function so it works in proxified environment
+rmarkdown_shiny_server.override <- function (dir, file, encoding, auto_reload, render_args) 
+{
+  function(input, output, session) {
+    # RCloud.mod: flexdashboard path is always '/', so it is fixed to single document.
+    # path_info <- utils::URLdecode(session$request$PATH_INFO)
+    # if (identical(substr(path_info, nchar(path_info) - 10, 
+    #                      nchar(path_info)), "/websocket/")) {
+    #   path_info <- substr(path_info, 1, nchar(path_info) - 
+    #                         11)
+    # }
+    # if (!nzchar(path_info)) {
+    #   path_info <- file
+    # }
+    path_info <- file
+    file <- rmarkdown:::resolve_relative(dir, path_info)
+    reactive_file <- if (auto_reload) 
+      shiny::reactiveFileReader(500, session, file, identity)
+    else function() {
+      file
+    }
+    envir_global <- render_args[["envir"]]
+    envir_server <- list2env(list(input = input, output = output, 
+                                  session = session), parent = envir_global)
+    render_args$envir <- new.env(parent = envir_server)
+    doc <- shiny::reactive({
+      out <- rmarkdown:::rmd_cached_output(file, encoding)
+      output_dest <- out$dest
+      if (out$cached) {
+        if (nchar(out$resource_folder) > 0) {
+          shiny::addResourcePath(basename(out$resource_folder), 
+                                 out$resource_folder)
+        }
+        return(out$shiny_html)
+      }
+      if (!file.exists(dirname(output_dest))) {
+        dir.create(dirname(output_dest), recursive = TRUE, 
+                   mode = "0700")
+      }
+      resource_folder <- rmarkdown:::knitr_files_dir(output_dest)
+      rmarkdown:::perf_timer_reset_all()
+      dependencies <- list()
+      shiny_dependency_resolver <- function(deps) {
+        dependencies <<- deps
+        list()
+      }
+      output_opts <- list(self_contained = FALSE, copy_resources = TRUE, 
+                          dependency_resolver = shiny_dependency_resolver)
+      message("\f")
+      args <- rmarkdown:::merge_lists(list(input = reactive_file(), 
+                                           output_file = output_dest, output_dir = dirname(output_dest), 
+                                           output_options = output_opts, intermediates_dir = dirname(output_dest), 
+                                           runtime = "shiny"), render_args)
+      result_path <- shiny::maskReactiveContext(do.call(render, 
+                                                        args))
+      if (!rmarkdown:::dir_exists(resource_folder)) 
+        dir.create(resource_folder, recursive = TRUE)
+      shiny::addResourcePath(basename(resource_folder), 
+                             resource_folder)
+      dependencies <- append(dependencies, list(rmarkdown:::create_performance_dependency(resource_folder)))
+      rmarkdown:::write_shiny_deps(resource_folder, dependencies)
+      if (nzchar(Sys.getenv("RSTUDIO"))) 
+        dependencies <- append(dependencies, list(rmarkdown:::html_dependency_rsiframe()))
+      if (!isTRUE(out$cacheable)) {
+        shiny::onReactiveDomainEnded(shiny::getDefaultReactiveDomain(), 
+                                     function() {
+                                       unlink(result_path)
+                                       unlink(resource_folder, recursive = TRUE)
+                                     })
+      }
+      rmarkdown:::shinyHTML_with_deps(result_path, dependencies)
+    })
+    doc_ui <- shiny::renderUI({
+      doc()
+    })
+    if (exists("snapshotPreprocessOutput", asNamespace("shiny"))) {
+      doc_ui <- shiny::snapshotPreprocessOutput(doc_ui, 
+                                                function(value) {
+                                                  value$html <- sprintf("[html data sha1: %s]", 
+                                                                        digest::digest(value$html, algo = "sha1", 
+                                                                                       serialize = FALSE))
+                                                  value
+                                                })
+    }
+    output$`__reactivedoc__` <- doc_ui
+  }
+}
+
+# Overriden rmarkdown:::shiny_prerendered_app which uses rcloud.shiny to spin up shiny app
+shiny_prerendered_app.override <- function (input_rmd, encoding, render_args, renderer = renderer) 
+{
+  html <- rmarkdown:::shiny_prerendered_html(input_rmd, encoding, render_args)
+  deps <- attr(html, "html_dependencies")
+  server_envir = new.env(parent = globalenv())
+  html_lines <- strsplit(html, "\n", fixed = TRUE)[[1]]
+  server_start_context <- rmarkdown:::shiny_prerendered_extract_context(html_lines, 
+                                                            "server-start")
+  server_start_code <- paste(c(server_start_context, rmarkdown:::shiny_prerendered_extract_context(html_lines, 
+                                                                                       "data")), collapse = "\n")
+  onStart <- function() {
+    assign(".shiny_prerendered_server_start_code", server_start_code, 
+           envir = server_envir)
+    eval(parse(text = server_start_context), envir = server_envir)
+    rmarkdown:::shiny_prerendered_data_load(input_rmd, server_envir)
+    lockEnvironment(server_envir)
+  }
+  .server_context <- rmarkdown:::shiny_prerendered_extract_context(html_lines, 
+                                                       "server")
+  server_envir$.server_context <- .server_context
+  server <- function(input, output, session) {
+    eval(parse(text = .server_context))
+  }
+  environment(server) <- new.env(parent = server_envir)
+  server_contexts <- c("server-start", "data", "server")
+  html_lines <- rmarkdown:::shiny_prerendered_remove_contexts(html_lines, 
+                                                  server_contexts)
+  html <- HTML(paste(html_lines, collapse = "\n"))
+  html <- htmltools::attachDependencies(html, deps)
+  
+  rcloud.shiny:::rcloud.shinyAppInternal(ui = function(req) html, 
+                                         uiPattern = "^/$|^(/.*\\.[Rr][Mm][Dd])$", 
+                                         onStart = onStart, 
+                                         server = server,
+                                         renderer = renderer)
+}

--- a/inst/javascript/rcloud.flexdashboard.js
+++ b/inst/javascript/rcloud.flexdashboard.js
@@ -51,6 +51,14 @@
                 .css('visibility', 'visible')
                 .html(html);
             k(null, target);
+        },
+        
+        renderShinyUrl: function(target, url, k) {
+            $('#rcloud-flexdashboard-loading').remove();
+            var content = '<iframe src="'+url+'" class="rcloud-shiny" frameBorder="0" style="position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;"></iframe>';
+            document.title = "RCloud flexdashboard";
+            $(target).html(content);
+            k(null, target);
         }
     };
 

--- a/inst/www/js/require-flexdashboard.js
+++ b/inst/www/js/require-flexdashboard.js
@@ -1,9 +1,6 @@
 requirejs.config(requirejs_config_obj); // jshint ignore:line
-
 var deps = common_deps; // jshint ignore:line
-
 deps.push(
     // rcloud's mini.js and bundle
     '../../shared.R/rcloud.flexdashboard/js/rcloud-flexdashboard', 'rcloud_bundle');
-
 start_require(deps); // jshint ignore:line


### PR DESCRIPTION
If rcloud.shiny is available in RCloud, then rcloud.flexdashboard will support shiny and shiny_prerendered runtimes.
shiny integration is implemented by overriden functions from rmarkdown so they use rcloud.shiny implementations of shiny startup functions.

FIX #20 

This change depends on: https://github.com/att/rcloud.shiny/pull/25

Note:
Although I made the rcloud.flexdashboard to clean up temporary directory created in 'render' function when RCloud session is closed, there are some temporary files created by rmarkdown which are not removed. I've spent couple of hours on trying to make rmarkdown to put these files into some location that we can safely clean up (or to remove them itself), but unfortunately a lot of functions in rmarkdown create temporary files directly in temporary directory. Sorting this out would require rewriting whole stack of functions from rmarkdown package in rcloud.flexdashboard or contributing to rmarkdown package - what would be preferable, I think. 

Both solutions though are couple days of effort I am afraid...
